### PR TITLE
Update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,11 @@
-MIT License
+All of the images in this project have been made available to this project
+by Chiara Bianchimani and are copyrighted. Any other use must be authorized
+by the author which holds all the rights for those images.
 
-Copyright (c) 2017 Richard Davey
+Any other file of this project is available under the MIT license as follows:
+
+Copyright (c) 2018 Alessandro Astone, Chiara Bianchimani,
+                   Giacomo Brosolo, Andrea Franchini
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Chiara aveva chiesto del copyright sulle immagini del progetto. Dato che non sono da considerarsi Software, le ho escluse dalla licenza MIT e attribuitone il diritto d'autore e di non replica.
Also, il nome del copyright holder era rimasto all'autore del progetto demo di Photon. Ho inserito tutti i nomi, in ordine alfabetico.